### PR TITLE
Update the mileage chart to just show TRIMP

### DIFF
--- a/dashboard/src/lib/api/fetch.ts
+++ b/dashboard/src/lib/api/fetch.ts
@@ -5,7 +5,9 @@ import type {
   DayMileage,
   RawDayMileage,
   RawDayTrainingLoad,
-  DayTrainingLoad
+  DayTrainingLoad,
+  RawDayTrimp,
+  DayTrimp,
 } from "./types";
 
 
@@ -218,4 +220,30 @@ function dayTrainingLoadFromRawDayTrainingLoad(
     date,
     training_load: rawDayTrainingLoad.training_load,
   };
+}
+
+function dayTrimpFromRawDayTrimp(rawDayTrimp: RawDayTrimp): DayTrimp {
+  return {
+    date: new Date(rawDayTrimp.date + "T00:00:00"), // Ensure it's treated as local date
+    trimp: rawDayTrimp.trimp,
+  };
+}
+
+export async function fetchDayTrimp(
+  start?: Date,
+  end?: Date,
+): Promise<DayTrimp[]> {
+  const url = new URL(`${import.meta.env.VITE_API_URL}/metrics/trimp/by-day`);
+  if (start) {
+    url.searchParams.set("start", toDateString(start));
+  }
+  if (end) {
+    url.searchParams.set("end", toDateString(end));
+  }
+  const res = await fetch(url);
+  if (!res.ok) {
+    throw new Error(`Failed to fetch day TRIMP: ${res.statusText}`);
+  }
+  const rawDayTrimps = await (res.json() as Promise<RawDayTrimp[]>);
+  return rawDayTrimps.map(dayTrimpFromRawDayTrimp);
 }

--- a/dashboard/src/lib/api/types.ts
+++ b/dashboard/src/lib/api/types.ts
@@ -53,3 +53,13 @@ export type DayTrainingLoad = {
   date: Date;
   training_load: TrainingLoad;
 };
+
+export type RawDayTrimp = {
+  date: string; // ISO 8601 string (from Python's `date`)
+  trimp: number;
+};
+
+export type DayTrimp = {
+  date: Date;
+  trimp: number;
+};

--- a/dashboard/src/panels/TimePeriodStatsPanel/DailyTrimpChart.tsx
+++ b/dashboard/src/panels/TimePeriodStatsPanel/DailyTrimpChart.tsx
@@ -1,5 +1,5 @@
 import {
-  ComposedChart,
+  BarChart,
   Bar,
   XAxis,
   YAxis,
@@ -15,11 +15,10 @@ import { format } from "date-fns";
 
 export interface DayData {
   date: Date;
-  mileage: number;
-  exertion: number;
+  trimp: number;
 }
 
-export function MileageExertionChart({
+export function DailyTrimpChart({
   title,
   data,
 }: {
@@ -28,18 +27,13 @@ export function MileageExertionChart({
 }) {
   const chartData = data.map((d) => ({
     date: format(d.date, "MMM d"),
-    mileage: d.mileage,
-    exertion: d.exertion,
+    trimp: Math.round(d.trimp * 10) / 10,
   }));
 
   const chartConfig: ChartConfig = {
-    mileage: {
-      label: "Daily Miles",
-      color: "var(--primary)",
-    },
-    exertion: {
+    trimp: {
       label: "TRIMP",
-      color: "var(--muted-foreground)",
+      color: "var(--primary)",
     },
   };
 
@@ -47,33 +41,22 @@ export function MileageExertionChart({
     <div className="w-full flex flex-col items-start">
       {title && <h3 className="mx-16 font-semibold">{title}</h3>}
       <ChartContainer config={chartConfig} className="w-full max-w-4xl mx-auto">
-        <ComposedChart
+        <BarChart
           data={chartData}
           margin={{ top: 20, right: 50, bottom: 20, left: 50 }}
         >
           <CartesianGrid strokeDasharray="3 3" stroke="#dddddd"/>
           <XAxis dataKey="date" tick={{ fontSize: 12 }} />
           <YAxis 
-            yAxisId="mileage"
             label={{
-              value: "Miles",
+              value: "TRIMP",
               angle: -90,
               position: "insideLeft",
             }}
           />
-          <YAxis 
-            yAxisId="exertion"
-            orientation="right"
-            label={{
-              value: "TRIMP",
-              angle: 90,
-              position: "insideRight",
-            }}
-          />
           <ChartTooltip content={<ChartTooltipContent />} />
-          <Bar yAxisId="mileage" dataKey="mileage" fill="var(--primary)" />
-          <Bar yAxisId="exertion" dataKey="exertion" fill="var(--muted-foreground)" />
-        </ComposedChart>
+          <Bar dataKey="trimp" fill="var(--primary)" />
+        </BarChart>
       </ChartContainer>
     </div>
   );

--- a/dashboard/src/panels/TimePeriodStatsPanel/MileageExertionChart.tsx
+++ b/dashboard/src/panels/TimePeriodStatsPanel/MileageExertionChart.tsx
@@ -1,0 +1,80 @@
+import {
+  ComposedChart,
+  Bar,
+  XAxis,
+  YAxis,
+  CartesianGrid,
+} from "recharts";
+import {
+  type ChartConfig,
+  ChartContainer,
+  ChartTooltip,
+  ChartTooltipContent,
+} from "@/components/ui/chart";
+import { format } from "date-fns";
+
+export interface DayData {
+  date: Date;
+  mileage: number;
+  exertion: number;
+}
+
+export function MileageExertionChart({
+  title,
+  data,
+}: {
+  title?: string;
+  data: DayData[];
+}) {
+  const chartData = data.map((d) => ({
+    date: format(d.date, "MMM d"),
+    mileage: d.mileage,
+    exertion: d.exertion,
+  }));
+
+  const chartConfig: ChartConfig = {
+    mileage: {
+      label: "Daily Miles",
+      color: "var(--primary)",
+    },
+    exertion: {
+      label: "TRIMP",
+      color: "var(--muted-foreground)",
+    },
+  };
+
+  return (
+    <div className="w-full flex flex-col items-start">
+      {title && <h3 className="mx-16 font-semibold">{title}</h3>}
+      <ChartContainer config={chartConfig} className="w-full max-w-4xl mx-auto">
+        <ComposedChart
+          data={chartData}
+          margin={{ top: 20, right: 50, bottom: 20, left: 50 }}
+        >
+          <CartesianGrid strokeDasharray="3 3" stroke="#dddddd"/>
+          <XAxis dataKey="date" tick={{ fontSize: 12 }} />
+          <YAxis 
+            yAxisId="mileage"
+            label={{
+              value: "Miles",
+              angle: -90,
+              position: "insideLeft",
+            }}
+          />
+          <YAxis 
+            yAxisId="exertion"
+            orientation="right"
+            label={{
+              value: "TRIMP",
+              angle: 90,
+              position: "insideRight",
+            }}
+          />
+          <ChartTooltip content={<ChartTooltipContent />} />
+          <Bar yAxisId="mileage" dataKey="mileage" fill="var(--primary)" />
+          <Bar yAxisId="exertion" dataKey="exertion" fill="var(--muted-foreground)" />
+        </ComposedChart>
+      </ChartContainer>
+    </div>
+  );
+}


### PR DESCRIPTION
  ## Summary

  Replace the mileage chart with a clean daily TRIMP (Training Impulse) visualization in the Time
  Period panel.

  - **Renamed tab**: "Mileage" → "Daily Load" to better reflect the training load focus
  - **Simplified chart**: Replaced dual-bar mileage/exertion chart with single-bar daily TRIMP
  chart
  - **Improved data consistency**: All references now use "trimp" terminology consistently
  - **Enhanced UX**: Removed unnecessary chart title and rounded TRIMP values to 1 decimal place

  ## Changes

  ### Frontend Updates
  - **New component**: `DailyTrimpChart` (renamed from `MileageExertionChart`) displays daily TRIMP
   as single bars
  - **API integration**: Added `fetchDayTrimp()` function and `DayTrimp` types for new TRIMP
  endpoint
  - **Consistent naming**: Updated all variable names, interfaces, and chart configs to use "trimp"
   instead of "load"
  - **UI polish**:
    - Y-axis and tooltip now properly labeled as "TRIMP"
    - Values rounded to 1 decimal place for cleaner display
    - Removed chart title to match design consistency

  ### Technical Details
  - Uses existing `/metrics/trimp/by-day` API endpoint
  - Chart built with Recharts `BarChart` component
  - Maintains existing date filtering and time range functionality
  - Follows established code patterns and TypeScript conventions