### PR TITLE
Replace data refresh notification with toast

### DIFF
--- a/dashboard/package-lock.json
+++ b/dashboard/package-lock.json
@@ -27,6 +27,7 @@
         "react-day-picker": "^8.10.1",
         "react-dom": "^19.1.0",
         "recharts": "^2.15.3",
+        "sonner": "^2.0.6",
         "tailwind-merge": "^3.3.0",
         "zustand": "^5.0.5"
       },
@@ -4653,6 +4654,16 @@
       "dev": true,
       "engines": {
         "node": ">=8"
+      }
+    },
+    "node_modules/sonner": {
+      "version": "2.0.6",
+      "resolved": "https://registry.npmjs.org/sonner/-/sonner-2.0.6.tgz",
+      "integrity": "sha512-yHFhk8T/DK3YxjFQXIrcHT1rGEeTLliVzWbO0xN8GberVun2RiBnxAjXAYpZrqwEVHBG9asI/Li8TAAhN9m59Q==",
+      "license": "MIT",
+      "peerDependencies": {
+        "react": "^18.0.0 || ^19.0.0 || ^19.0.0-rc",
+        "react-dom": "^18.0.0 || ^19.0.0 || ^19.0.0-rc"
       }
     },
     "node_modules/source-map-js": {

--- a/dashboard/package.json
+++ b/dashboard/package.json
@@ -30,6 +30,7 @@
     "react-day-picker": "^8.10.1",
     "react-dom": "^19.1.0",
     "recharts": "^2.15.3",
+    "sonner": "^2.0.6",
     "tailwind-merge": "^3.3.0",
     "zustand": "^5.0.5"
   },

--- a/dashboard/src/App.tsx
+++ b/dashboard/src/App.tsx
@@ -1,19 +1,16 @@
-import { useState } from "react";
 import {
   AllTimeStatsPanel,
   ShoesStatsPanel,
   TimePeriodStatsPanel,
 } from "./panels";
 import { RefreshButton } from "./components/RefreshButton";
+import { Toaster } from "./components/ui/sonner";
+import { toast } from "sonner";
 import type { RefreshDataResponse } from "./lib/api/fetch";
 
 function App() {
-  const [refreshStatus, setRefreshStatus] = useState<string | null>(null);
-
   const handleRefreshComplete = (data: RefreshDataResponse) => {
-    setRefreshStatus(`Loaded ${data.total_runs} runs`);
-    // Clear the status after 3 seconds
-    setTimeout(() => setRefreshStatus(null), 3000);
+    toast.success(`Loaded ${data.total_runs} runs`);
   };
 
   return (
@@ -24,11 +21,6 @@ function App() {
         </h1>
         <div className="flex flex-col items-end gap-2">
           <RefreshButton onRefreshComplete={handleRefreshComplete} />
-          {refreshStatus && (
-            <span className="text-sm text-green-600 font-medium">
-              {refreshStatus}
-            </span>
-          )}
         </div>
       </div>
       <div className="flex flex-row justify-between gap-x-6">
@@ -36,6 +28,7 @@ function App() {
         <TimePeriodStatsPanel />
         <ShoesStatsPanel className="w-96 flex-grow-0" />
       </div>
+      <Toaster />
     </div>
   );
 }

--- a/dashboard/src/components/ui/sonner.tsx
+++ b/dashboard/src/components/ui/sonner.tsx
@@ -1,0 +1,26 @@
+"use client"
+
+import { Toaster as Sonner, type ToasterProps } from "sonner"
+
+const Toaster = ({ ...props }: ToasterProps) => {
+  return (
+    <Sonner
+      theme="system"
+      className="toaster group"
+      toastOptions={{
+        classNames: {
+          toast:
+            "group toast group-[.toaster]:bg-background group-[.toaster]:text-foreground group-[.toaster]:border-border group-[.toaster]:shadow-lg",
+          description: "group-[.toast]:text-muted-foreground",
+          actionButton:
+            "group-[.toast]:bg-primary group-[.toast]:text-primary-foreground",
+          cancelButton:
+            "group-[.toast]:bg-muted group-[.toast]:text-muted-foreground",
+        },
+      }}
+      {...props}
+    />
+  )
+}
+
+export { Toaster }


### PR DESCRIPTION
## Summary
- Replaces disruptive green text with clean toast notification after data refresh
- Adds Sonner toast library following shadcn/ui patterns
- Removes layout-affecting status display that appeared in header

## Test plan
- [x] Refresh data and verify toast appears instead of green text
- [x] Confirm layout remains stable during and after refresh
- [x] Verify toast automatically dismisses

🤖 Generated with [Claude Code](https://claude.ai/code)