### PR TITLE
Fix calendar picker to open on selected date's month

### DIFF
--- a/dashboard/src/components/DatePicker.tsx
+++ b/dashboard/src/components/DatePicker.tsx
@@ -39,6 +39,7 @@ export function DatePicker({
           mode="single"
           selected={value}
           onSelect={(d) => d && onChange(d)}
+          defaultMonth={value}
           initialFocus
         />
       </PopoverContent>


### PR DESCRIPTION
## Summary
- Fix calendar picker to open on the month containing the selected date instead of always opening on the current month
- Improves user experience when working with dates far from the current month

## Changes
- **DatePicker.tsx**: Add `defaultMonth={value}` prop to Calendar component
- Calendar now uses the selected date to determine which month to display initially

## Problem
When clicking on Start Date or End Date picker, the calendar would always open to the current month (July 2025), even if the selected date was in a different month (e.g., June 2025 for "30 days ago").

## Solution
Added the `defaultMonth` prop to the react-day-picker Calendar component, which tells it to initially display the month containing the currently selected date.

## Test plan
- [x] Build passes without errors
- [x] Linting passes (only pre-existing warnings)
- [x] Calendar now opens to correct month based on selected date
- [x] Works for both Start Date and End Date pickers
- [x] No breaking changes to existing functionality

## Before/After
**Before**: Calendar always opened to current month regardless of selected date  
**After**: Calendar opens to the month containing the selected date

Fixes #14

🤖 Generated with [Claude Code](https://claude.ai/code)