### PR TITLE
Generate deterministic run IDs

### DIFF
--- a/api/DATABASE.md
+++ b/api/DATABASE.md
@@ -1,0 +1,147 @@
+# Database Setup Guide
+
+This application has been migrated from in-memory storage to PostgreSQL for persistent data storage.
+
+## Prerequisites
+
+1. **PostgreSQL Database**: You need a running PostgreSQL instance
+2. **Environment Variables**: Set up your `DATABASE_URL` environment variable
+
+## Environment Setup
+
+Add the following to your `.env` file in the `api/` directory:
+
+```env
+# Database connection
+DATABASE_URL=postgresql://username:password@localhost:5432/fitness_db
+
+# Existing variables (Strava, MMF, etc.)
+# ... your other environment variables ...
+```
+
+### Database URL Format
+
+The `DATABASE_URL` should follow this format:
+```
+postgresql://[username[:password]@][host[:port]][/database]
+```
+
+Examples:
+- Local development: `postgresql://postgres:password@localhost:5432/fitness_db`
+- With connection parameters: `postgresql://user:pass@localhost:5432/fitness_db?sslmode=require`
+
+## Database Migration
+
+### 1. Install Dependencies
+
+```bash
+cd api
+uv sync
+```
+
+### 2. Create Database
+
+Create your PostgreSQL database (this step depends on your PostgreSQL setup):
+
+```sql
+CREATE DATABASE fitness_db;
+```
+
+### 3. Run Migrations
+
+Apply the database schema:
+
+```bash
+cd api
+alembic upgrade head
+```
+
+This creates the `runs` table with the following structure:
+- `id`: Primary key (VARCHAR) - Deterministic ID
+  - Strava runs: `strava_{strava_id}` (e.g., `strava_12345`)
+  - MMF runs: `mmf_{hash}` where hash is generated from date, distance, and duration
+- `datetime_utc`: When the run occurred (UTC)
+- `type`: Run type ('Outdoor Run' or 'Treadmill Run')
+- `distance`: Distance in miles
+- `duration`: Duration in seconds
+- `source`: Data source ('MapMyFitness' or 'Strava')
+- `avg_heart_rate`: Average heart rate (optional)
+- `shoes`: Shoe name (optional)
+- `created_at`: Record creation timestamp
+- `updated_at`: Record update timestamp
+
+## Database Operations
+
+### Raw SQL Access
+
+The application uses raw SQL queries via psycopg3. Key modules:
+
+- `fitness/db/connection.py`: Database connection management
+- `fitness/db/runs.py`: Run-specific database operations
+
+### Available Operations
+
+```python
+from fitness.db.runs import *
+
+# Get all runs
+runs = get_all_runs()
+
+# Get runs in date range
+runs = get_runs_in_date_range(start_date, end_date)
+
+# Create a new run (uses ON CONFLICT DO NOTHING for idempotency)
+run_id = create_run(run_object)
+
+# Bulk insert (also idempotent)
+count = bulk_create_runs(list_of_runs)
+
+# Check if run exists
+exists = run_exists(run_object)
+```
+
+### Refreshing Data
+
+The API includes functionality to refresh data from external sources:
+
+```python
+# This will re-fetch from Strava and MMF, then update the database
+fresh_runs = refresh_runs_data()
+```
+
+## Creating New Migrations
+
+When you need to modify the database schema:
+
+```bash
+cd api
+alembic revision -m "Description of your change"
+```
+
+Edit the generated migration file in `alembic/versions/`, then apply it:
+
+```bash
+alembic upgrade head
+```
+
+## Troubleshooting
+
+### Connection Issues
+
+1. **Check DATABASE_URL**: Ensure the format is correct and the database exists
+2. **Database permissions**: Make sure your user has CREATE/INSERT/SELECT permissions
+3. **Network connectivity**: Verify you can connect to the PostgreSQL server
+
+### Migration Issues
+
+1. **Check dependencies**: Run `uv sync` to ensure all packages are installed
+2. **Check database exists**: The database must exist before running migrations
+3. **Check credentials**: Ensure your DATABASE_URL credentials are correct
+
+## Architecture Notes
+
+- **No ORM**: Uses raw SQL with psycopg3 for direct database access
+- **Connection management**: Uses context managers for automatic connection cleanup
+- **Migrations**: Alembic handles schema versioning and migrations
+- **Performance**: Includes database indexes on commonly queried fields
+- **Idempotency**: Insert operations use `ON CONFLICT DO NOTHING` to prevent duplicate errors

--- a/api/alembic/versions/0001_create_runs_table.py
+++ b/api/alembic/versions/0001_create_runs_table.py
@@ -1,0 +1,46 @@
+"""Create runs table
+
+Revision ID: 0001
+Revises: 
+Create Date: 2024-12-17 22:09:00.000000
+
+"""
+from typing import Sequence, Union
+
+from alembic import op
+import sqlalchemy as sa
+
+
+# revision identifiers, used by Alembic.
+revision: str = '0001'
+down_revision: Union[str, Sequence[str], None] = None
+branch_labels: Union[str, Sequence[str], None] = None
+depends_on: Union[str, Sequence[str], None] = None
+
+
+def upgrade() -> None:
+    """Upgrade schema."""
+    op.execute("""
+        CREATE TABLE runs (
+            id VARCHAR(100) PRIMARY KEY,
+            datetime_utc TIMESTAMP NOT NULL,
+            type VARCHAR(50) NOT NULL CHECK (type IN ('Outdoor Run', 'Treadmill Run')),
+            distance FLOAT NOT NULL,
+            duration FLOAT NOT NULL,
+            source VARCHAR(50) NOT NULL CHECK (source IN ('MapMyFitness', 'Strava')),
+            avg_heart_rate FLOAT,
+            shoes VARCHAR(255),
+            created_at TIMESTAMP DEFAULT CURRENT_TIMESTAMP,
+            updated_at TIMESTAMP DEFAULT CURRENT_TIMESTAMP
+        )
+    """)
+    
+    # Create indexes for common queries
+    op.execute("CREATE INDEX idx_runs_datetime_utc ON runs (datetime_utc)")
+    op.execute("CREATE INDEX idx_runs_source ON runs (source)")
+    op.execute("CREATE INDEX idx_runs_shoes ON runs (shoes)")
+
+
+def downgrade() -> None:
+    """Downgrade schema."""
+    op.execute("DROP TABLE IF EXISTS runs")

--- a/api/fitness/db/runs.py
+++ b/api/fitness/db/runs.py
@@ -1,0 +1,120 @@
+from datetime import datetime, date
+from typing import List, Optional
+
+from fitness.models import Run
+from .connection import get_db_cursor
+
+
+def create_run(run: Run) -> str:
+    """Insert a new run into the database and return its ID."""
+    with get_db_cursor() as cursor:
+        cursor.execute("""
+            INSERT INTO runs (id, datetime_utc, type, distance, duration, source, avg_heart_rate, shoes)
+            VALUES (%s, %s, %s, %s, %s, %s, %s, %s)
+            ON CONFLICT (id) DO NOTHING
+            RETURNING id
+        """, (
+            run.id,
+            run.datetime_utc,
+            run.type,
+            run.distance,
+            run.duration,
+            run.source,
+            run.avg_heart_rate,
+            run.shoes
+        ))
+        result = cursor.fetchone()
+        return result[0] if result else run.id
+
+
+def get_all_runs() -> List[Run]:
+    """Get all runs from the database."""
+    with get_db_cursor() as cursor:
+        cursor.execute("""
+            SELECT id, datetime_utc, type, distance, duration, source, avg_heart_rate, shoes
+            FROM runs
+            ORDER BY datetime_utc
+        """)
+        rows = cursor.fetchall()
+        return [_row_to_run(row) for row in rows]
+
+
+def get_runs_in_date_range(start_date: date, end_date: date) -> List[Run]:
+    """Get runs within a specific date range (based on UTC dates)."""
+    with get_db_cursor() as cursor:
+        cursor.execute("""
+            SELECT id, datetime_utc, type, distance, duration, source, avg_heart_rate, shoes
+            FROM runs
+            WHERE DATE(datetime_utc) BETWEEN %s AND %s
+            ORDER BY datetime_utc
+        """, (start_date, end_date))
+        rows = cursor.fetchall()
+        return [_row_to_run(row) for row in rows]
+
+
+def get_runs_by_source(source: str) -> List[Run]:
+    """Get all runs from a specific source."""
+    with get_db_cursor() as cursor:
+        cursor.execute("""
+            SELECT id, datetime_utc, type, distance, duration, source, avg_heart_rate, shoes
+            FROM runs
+            WHERE source = %s
+            ORDER BY datetime_utc
+        """, (source,))
+        rows = cursor.fetchall()
+        return [_row_to_run(row) for row in rows]
+
+
+def delete_runs_by_source(source: str) -> int:
+    """Delete all runs from a specific source. Returns the number of deleted rows."""
+    with get_db_cursor() as cursor:
+        cursor.execute("DELETE FROM runs WHERE source = %s", (source,))
+        return cursor.rowcount
+
+
+def run_exists(run: Run) -> bool:
+    """Check if a run with the same ID already exists."""
+    with get_db_cursor() as cursor:
+        cursor.execute("""
+            SELECT 1 FROM runs
+            WHERE id = %s
+            LIMIT 1
+        """, (run.id,))
+        return cursor.fetchone() is not None
+
+
+def bulk_create_runs(runs: List[Run]) -> int:
+    """Insert multiple runs into the database. Returns the number of inserted rows."""
+    if not runs:
+        return 0
+    
+    with get_db_cursor() as cursor:
+        # Use execute_batch for better performance with multiple inserts
+        data = [
+            (run.id, run.datetime_utc, run.type, run.distance, run.duration, 
+             run.source, run.avg_heart_rate, run.shoes)
+            for run in runs
+        ]
+        
+        cursor.executemany("""
+            INSERT INTO runs (id, datetime_utc, type, distance, duration, source, avg_heart_rate, shoes)
+            VALUES (%s, %s, %s, %s, %s, %s, %s, %s)
+            ON CONFLICT (id) DO NOTHING
+        """, data)
+        
+        return cursor.rowcount
+
+
+def _row_to_run(row) -> Run:
+    """Convert a database row to a Run object."""
+    id_, datetime_utc, type_, distance, duration, source, avg_heart_rate, shoes = row
+    return Run(
+        id=id_,
+        datetime_utc=datetime_utc,
+        type=type_,
+        distance=distance,
+        duration=duration,
+        source=source,
+        avg_heart_rate=avg_heart_rate,
+        shoes=shoes
+    )


### PR DESCRIPTION
Add deterministic ID to `Run` model and database schema to support idempotent data imports.

---
<a href="https://cursor.com/background-agent?bcId=bc-23464be0-735b-4366-999d-19847dd0237b">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg">
    <img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg">
  </picture>
</a>
<a href="https://cursor.com/agents?id=bc-23464be0-735b-4366-999d-19847dd0237b">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg">
    <img alt="Open in Web" src="https://cursor.com/open-in-web.svg">
  </picture>
</a>

<sub>[Learn more](https://docs.cursor.com/background-agent/web-and-mobile) about Cursor Agents</sub>