### PR TITLE
Set up end-to-end testing

### DIFF
--- a/README.md
+++ b/README.md
@@ -3,3 +3,18 @@
 A Python API (in `./api`) and a React front end (in `./dashboard`) that together display my running data from Strava and MapMyRun.
 
 ![dashboard](./images/dashboard.png)
+
+## Testing
+
+See `api/README.md` for full details. Quick start:
+
+```sh
+cd api
+uv sync --group dev
+# Unit tests
+make test
+# End-to-end API+DB tests (requires Docker)
+make e2e-test
+# External integration tests (Strava credentials required)
+make int-test
+```

--- a/api/Makefile
+++ b/api/Makefile
@@ -1,10 +1,14 @@
 # Unit tests only
 test:
-	uv run pytest -m "not integration"
+	uv run pytest -m "not integration and not e2e"
 
 # Integration tests only
 int-test:
 	uv run pytest -m "integration"
+
+# End-to-end tests only
+e2e-test:
+	uv run pytest -m "e2e"
 
 # All tests
 all-test:

--- a/api/README.md
+++ b/api/README.md
@@ -114,17 +114,35 @@ curl "http://localhost:8000/metrics/mileage/by-shoe"
 
 ## 8. Testing
 
-- **Unit tests only:**
+Before running tests, install dev dependencies (pytest, testcontainers, etc.):
+
+```sh
+uv sync --group dev
+```
+
+- **Unit tests only** (fast, no external services, no containers):
   ```sh
   make test
   ```
-- **All tests (including integration with Strava):**
+
+- **End-to-end (E2E) API + DB workflow tests** (uses Testcontainers Postgres + Alembic):
+  - Requires Docker running
+  ```sh
+  make e2e-test
+  ```
+
+- **Integration tests with Strava (external system)**:
+  - Requires valid Strava credentials in `.env.dev`
+  ```sh
+  make int-test
+  ```
+
+- **All tests**:
   ```sh
   make all-test
   ```
-  > Note: Integration tests require valid Strava credentials and may prompt for authorization.
 
-- **Linting, formatting, and type checks:**
+- **Linting, formatting, and type checks**:
   ```sh
   make lint
   make format

--- a/api/pyproject.toml
+++ b/api/pyproject.toml
@@ -22,6 +22,7 @@ dev = [
     "pytest-cov>=6.2.1",
     "ruff>=0.12.3",
     "ty>=0.0.1a16",
+    "testcontainers[postgres]>=4.6.0",
 ]
 
 [build-system]
@@ -31,5 +32,6 @@ build-backend = "hatchling.build"
 [tool.pytest.ini_options]
 markers = [
     "integration: marks tests that use an external system",
+    "e2e: end-to-end API + DB workflow tests",
 ]
 addopts = "--cov=fitness --cov-report html"

--- a/api/tests/e2e/conftest.py
+++ b/api/tests/e2e/conftest.py
@@ -1,0 +1,35 @@
+import os
+from pathlib import Path
+import pytest
+from testcontainers.postgres import PostgresContainer
+from alembic.config import Config
+from alembic import command
+from fastapi.testclient import TestClient
+
+# Ensure allowed environment for env_loader
+os.environ.setdefault("ENV", "dev")
+
+
+@pytest.fixture(scope="session")
+def db_url() -> str:
+    """Start a Postgres container, run migrations, and return the DB URL."""
+    with PostgresContainer("postgres:16") as pg:
+        raw_url = pg.get_connection_url()
+        # Normalize to psycopg3-compatible URL if needed
+        url = raw_url.replace("postgresql+psycopg2://", "postgresql://")
+        os.environ["DATABASE_URL"] = url
+
+        # Run Alembic migrations against this database
+        api_dir = Path(__file__).resolve().parents[2]
+        alembic_cfg = Config(str(api_dir / "alembic.ini"))
+        command.upgrade(alembic_cfg, "head")
+
+        yield url
+
+
+@pytest.fixture(scope="session")
+def client(db_url: str) -> TestClient:
+    """Create a FastAPI TestClient after DB is configured."""
+    from fitness.app.app import app
+
+    return TestClient(app)

--- a/api/tests/e2e/test_workflow.py
+++ b/api/tests/e2e/test_workflow.py
@@ -1,0 +1,64 @@
+import pytest
+from datetime import datetime
+from fitness.models import Run
+from fitness.db.runs import bulk_create_runs
+from fitness.models.shoe import generate_shoe_id
+
+
+@pytest.mark.e2e
+def test_minimal_workflow(client):
+    # Seed: create a run with a shoe name so it auto-creates the shoe and history
+    run = Run(
+        id="e2e_run_1",
+        datetime_utc=datetime(2024, 1, 1, 12, 0, 0),
+        type="Outdoor Run",
+        distance=5.0,
+        duration=1800.0,
+        source="Strava",
+        avg_heart_rate=150.0,
+    )
+    run._shoe_name = "E2E Test Shoe"
+
+    inserted = bulk_create_runs([run])
+    assert inserted == 1
+
+    # View runs
+    res = client.get("/runs")
+    assert res.status_code == 200
+    runs = res.json()
+    assert any(r["id"] == "e2e_run_1" for r in runs)
+
+    # Edit the run
+    res = client.patch(
+        "/runs/e2e_run_1",
+        json={
+            "distance": 5.5,
+            "changed_by": "e2e",
+            "change_reason": "adjust distance",
+        },
+    )
+    assert res.status_code == 200
+
+    # History should now include original + update
+    res = client.get("/runs/e2e_run_1/history")
+    assert res.status_code == 200
+    history = res.json()
+    assert len(history) >= 2
+
+    # Retire the shoe
+    shoe_id = generate_shoe_id("E2E Test Shoe")
+    res = client.patch(
+        f"/shoes/{shoe_id}",
+        json={"retired_at": "2024-12-31", "retirement_notes": "done"},
+    )
+    assert res.status_code == 200
+
+    # Verify appears in retired list
+    res = client.get("/shoes", params={"retired": True})
+    assert res.status_code == 200
+    retired = res.json()
+    assert any(s["id"] == shoe_id for s in retired)
+
+    # Unretire
+    res = client.patch(f"/shoes/{shoe_id}", json={"retired_at": None})
+    assert res.status_code == 200


### PR DESCRIPTION
Adds end-to-end API workflow tests, isolated via Testcontainers, and introduces a dedicated `e2e` pytest marker and Makefile target.

This is only a very basic test for now but I'll come back to it.

---
<a href="https://cursor.com/background-agent?bcId=bc-6534c906-b937-4c82-abd6-eba153189e76">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg">
    <img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg">
  </picture>
</a>
<a href="https://cursor.com/agents?id=bc-6534c906-b937-4c82-abd6-eba153189e76">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg">
    <img alt="Open in Web" src="https://cursor.com/open-in-web.svg">
  </picture>
</a>

