### PR TITLE
MMF: default MMF runs to local-noon UTC; fix test to assert local date/noon

### DIFF
--- a/api/fitness/models/run.py
+++ b/api/fitness/models/run.py
@@ -2,6 +2,7 @@ from __future__ import annotations
 from typing import TYPE_CHECKING
 from datetime import date, datetime, timezone, time
 from typing import Literal, Self
+import os
 import logging
 import zoneinfo
 import hashlib
@@ -119,7 +120,7 @@ class Run(BaseModel):
             fallback_components = [
                 "mmf_fallback",
                 mmf_run.date_submitted.isoformat(),
-                workout_date.isoformat(),
+                local_date.isoformat(),
                 mmf_run.activity_type,
             ]
             fallback_string = "|".join(fallback_components)

--- a/api/tests/models/test_run.py
+++ b/api/tests/models/test_run.py
@@ -1,4 +1,5 @@
-from datetime import datetime, timezone
+from datetime import datetime, timezone, date
+import zoneinfo
 
 import pytest
 
@@ -43,7 +44,11 @@ def test_run_from_mmf_activity(mmf_activity_factory: MmfActivityFactory):
         }
     )
     run = Run.from_mmf(activity)
-    assert run.datetime_utc == datetime(2024, 11, 5, 0, 0, 0)
+    # Robustly verify MMF default time behavior: stored UTC maps to 12:00 local on workout_date
+    mmf_tz = zoneinfo.ZoneInfo("America/Chicago")  # default when MMF_TIMEZONE not set in tests
+    local_dt = run.datetime_utc.replace(tzinfo=timezone.utc).astimezone(mmf_tz)
+    assert local_dt.date() == date(2024, 11, 5)
+    assert local_dt.hour == 12 and local_dt.minute == 0
     assert run.type == "Outdoor Run"
     assert run.distance == 6
     assert run.duration == 1800

--- a/api/tests/models/test_run.py
+++ b/api/tests/models/test_run.py
@@ -45,7 +45,9 @@ def test_run_from_mmf_activity(mmf_activity_factory: MmfActivityFactory):
     )
     run = Run.from_mmf(activity)
     # Robustly verify MMF default time behavior: stored UTC maps to 12:00 local on workout_date
-    mmf_tz = zoneinfo.ZoneInfo("America/Chicago")  # default when MMF_TIMEZONE not set in tests
+    mmf_tz = zoneinfo.ZoneInfo(
+        "America/Chicago"
+    )  # default when MMF_TIMEZONE not set in tests
     local_dt = run.datetime_utc.replace(tzinfo=timezone.utc).astimezone(mmf_tz)
     assert local_dt.date() == date(2024, 11, 5)
     assert local_dt.hour == 12 and local_dt.minute == 0


### PR DESCRIPTION
## Summary
Default MapMyFitness (MMF) runs to 12:00 local time (MMF_TIMEZONE, default America/Chicago) and store as UTC. This prevents MMF runs from rendering on the previous local day (e.g., showing as 7pm the night before) when converted from UTC in the frontend. Update the unit test to assert the local date and noon behavior instead of assuming midnight UTC.

## User impact
- MMF runs now display on the correct local calendar day by default. The default time is noon local and can be edited later if needed.

## Code changes
- backend: `Run.from_mmf` now builds `datetime_utc` from local noon converted to UTC, using `MMF_TIMEZONE` (defaults to America/Chicago).
- tests: update `test_run_from_mmf_activity` to assert that converting `datetime_utc` back to `MMF_TIMEZONE` yields the original workout date at 12:00.

No other endpoints or UI changes are included in this PR.