### PR TITLE
Dashboard cleanup: make RunsTable RunDetail-only and simplify keys

### DIFF
--- a/dashboard/src/components/RunsTable.tsx
+++ b/dashboard/src/components/RunsTable.tsx
@@ -271,7 +271,6 @@ function RunTableRow({
                 )}
               </div>
 
-              {/* Edit actions (RunDetail always has ID) */}
               {(
                 <DropdownMenu>
                   <DropdownMenuTrigger asChild>


### PR DESCRIPTION
## Summary
- Narrow `RunsTable` to accept `RunDetail[]` only
- Use `run.id` as the stable row key
- Remove union types and type guard usage in the table

## Rationale
- All consumers already provide `RunDetail` from `/runs-details`
- Simplifies types and reduces conditional code paths
- Stabilizes keys for fewer re-renders and clearer data flow

## Touch points
- `src/components/RunsTable.tsx`

## Testing
- `npm run build` passes
- No behavior change expected; purely type/structure cleanup