### PR TITLE
Dashboard cleanup: remove unused fetchRuns and legacy Run types

### DIFF
--- a/dashboard/src/lib/api/types.ts
+++ b/dashboard/src/lib/api/types.ts
@@ -13,12 +13,6 @@ export type RunSortBy =
   | "shoes";
 export type SortOrder = "asc" | "desc";
 
-// A run received from the API, before being parsed.
-// Deprecated basic run types; the UI uses RunDetail exclusively
-
-// Raw run with shoes from the API (explicit shoes field guaranteed)
-// Removed legacy RunWithShoes raw/display types; use RunDetail instead
-
 export type RawDayMileage = {
   date: string; // ISO 8601 string (from Python's `date`)
   mileage: number;

--- a/dashboard/src/lib/api/types.ts
+++ b/dashboard/src/lib/api/types.ts
@@ -14,27 +14,7 @@ export type RunSortBy =
 export type SortOrder = "asc" | "desc";
 
 // A run received from the API, before being parsed.
-export type RawRun = {
-  date?: string; // ISO 8601 string (from Python's `date`) - may be missing
-  datetime_utc?: string; // ISO 8601 datetime string (from Python's `datetime`)
-  type: RunType;
-  distance: number; // in miles
-  duration: number; // in seconds
-  source: RunSource;
-  avg_heart_rate?: number | null;
-  shoes?: string | null;
-};
-
-export type Run = {
-  date: Date;
-  datetime?: Date; // Full datetime when available
-  type: RunType;
-  distance: number; // in miles
-  duration: number; // in seconds
-  source: RunSource;
-  avg_heart_rate?: number | null;
-  shoes?: string | null;
-};
+// Deprecated basic run types; the UI uses RunDetail exclusively
 
 // Raw run with shoes from the API (explicit shoes field guaranteed)
 // Removed legacy RunWithShoes raw/display types; use RunDetail instead


### PR DESCRIPTION
## Summary
- Remove unused `fetchRuns` API wrapper
- Drop legacy `Run`/`RawRun` types and converter in favor of `RunDetail`

## Rationale
- The UI has fully standardized on `RunDetail` from `/runs-details`
- Eliminates dead code and reduces maintenance surface

## Touch points
- `src/lib/api/fetch.ts`
- `src/lib/api/types.ts`

## Testing
- `npm run build` succeeds
- Grep confirms no references to `fetchRuns`, `Run`, or `RawRun` remain in the UI