### PR TITLE
Refactor: targeted query invalidations + helpers

### DIFF
--- a/dashboard/src/components/RefreshButton.tsx
+++ b/dashboard/src/components/RefreshButton.tsx
@@ -3,6 +3,7 @@ import { useMutation, useQueryClient } from "@tanstack/react-query";
 import { Button } from "@/components/ui/button";
 import { refreshData } from "@/lib/api";
 import { notifyError, notifySuccess } from "@/lib/errors";
+import { invalidateAllDash } from "@/lib/invalidate";
 import type { RefreshDataResponse } from "@/lib/api";
 
 interface RefreshButtonProps {
@@ -16,8 +17,8 @@ export function RefreshButton({ onRefreshComplete }: RefreshButtonProps) {
   const refreshMutation = useMutation({
     mutationFn: refreshData,
     onSuccess: (data) => {
-      // Invalidate all queries to refetch data
-      queryClient.invalidateQueries();
+      // Targeted invalidation for dashboard data
+      invalidateAllDash(queryClient);
       setLastRefresh(new Date(data.updated_at));
       notifySuccess(data.message || "Data refreshed");
       onRefreshComplete?.(data);

--- a/dashboard/src/lib/invalidate.ts
+++ b/dashboard/src/lib/invalidate.ts
@@ -1,0 +1,31 @@
+import type { QueryClient } from "@tanstack/react-query";
+import { queryKeys } from "@/lib/queryKeys";
+
+export function invalidateRuns(queryClient: QueryClient) {
+  queryClient.invalidateQueries({ queryKey: queryKeys.group.runs() });
+}
+
+export function invalidateMetrics(queryClient: QueryClient) {
+  // Invalidate multiple related metric groups
+  queryClient.invalidateQueries({ queryKey: queryKeys.totalMiles() });
+  queryClient.invalidateQueries({ queryKey: queryKeys.milesByDay() });
+  queryClient.invalidateQueries({ queryKey: queryKeys.rollingMiles({}) });
+  queryClient.invalidateQueries({ queryKey: queryKeys.dayTrimp({}) });
+  queryClient.invalidateQueries({ queryKey: ["metrics"] });
+}
+
+export function invalidateShoes(queryClient: QueryClient) {
+  queryClient.invalidateQueries({ queryKey: queryKeys.shoesMileage(true) });
+  queryClient.invalidateQueries({ queryKey: queryKeys.shoesMileage(false) });
+}
+
+export function invalidateEnvironment(queryClient: QueryClient) {
+  queryClient.invalidateQueries({ queryKey: queryKeys.environment() });
+}
+
+export function invalidateAllDash(queryClient: QueryClient) {
+  invalidateRuns(queryClient);
+  invalidateMetrics(queryClient);
+  invalidateShoes(queryClient);
+  invalidateEnvironment(queryClient);
+}

--- a/dashboard/src/lib/queryKeys.ts
+++ b/dashboard/src/lib/queryKeys.ts
@@ -84,6 +84,13 @@ export const queryKeys = {
       params.sortOrder,
       params.synced ?? "all",
     ] as const,
+  // Helper groups for invalidation convenience (not for useQuery)
+  group: {
+    runs: () => ["recent-runs"] as const,
+    metrics: () => ["miles", "metrics", "day-trimp", "seconds"] as const,
+    shoes: () => ["miles", "by-shoe", "shoes"] as const,
+    environment: () => ["environment"] as const,
+  },
   bulkSync: (params: {
     startDate?: Date;
     endDate?: Date;


### PR DESCRIPTION
## Summary
- Introduce `lib/invalidate` with helpers to invalidate runs, metrics, shoes, and environment
- Update `RefreshButton` to use targeted invalidations instead of blanket `invalidateQueries()`
- Add grouped keys in `queryKeys` for convenience

## Rationale
- More explicit and efficient cache invalidation; easier to reuse in future mutations

## Touch points
- `src/lib/invalidate.ts`
- `src/components/RefreshButton.tsx`
- `src/lib/queryKeys.ts`

## Testing
- `npm run build` succeeds
- No functional changes intended