### PR TITLE
Polish: unify toast usage with lib/errors

### DIFF
--- a/dashboard/src/App.tsx
+++ b/dashboard/src/App.tsx
@@ -8,15 +8,15 @@ import { RefreshButton } from "./components/RefreshButton";
 import { EnvironmentIndicator } from "./components/EnvironmentIndicator";
 import { ThemeToggle } from "./components/ThemeToggle";
 import { Toaster } from "./components/ui/sonner";
-import { toast } from "sonner";
+import { notifySuccess, notifyInfo } from "@/lib/errors";
 import type { RefreshDataResponse } from "./lib/api/fetch";
 
 function App() {
   const handleRefreshComplete = (data: RefreshDataResponse) => {
     if (data.new_runs_inserted > 0) {
-      toast.success(`Added ${data.new_runs_inserted} new runs`);
+      notifySuccess(`Added ${data.new_runs_inserted} new runs`);
     } else {
-      toast.info("No new runs found");
+      notifyInfo("No new runs found");
     }
   };
 

--- a/dashboard/src/components/BulkSyncDialog.tsx
+++ b/dashboard/src/components/BulkSyncDialog.tsx
@@ -17,6 +17,7 @@ import { invalidateRuns } from "@/lib/invalidate";
 import { getUserTimezone } from "@/lib/timezone";
 import { formatRunDate, formatRunDistance } from "@/lib/runUtils";
 import { toast } from "sonner";
+import { notifyError, notifySuccess } from "@/lib/errors";
 import { runWithConcurrency } from "@/lib/async";
 
 interface BulkSyncDialogProps {
@@ -151,9 +152,9 @@ export function BulkSyncDialog({
       });
 
       if (failureCount === 0) {
-        toast.success(`Synced ${successCount} runs to Google Calendar`);
+        notifySuccess(`Synced ${successCount} runs to Google Calendar`);
       } else if (successCount === 0) {
-        toast.error("Failed to sync selected runs");
+        notifyError(new Error("Failed to sync selected runs"));
       } else {
         toast.message("Bulk sync finished", {
           description: `${successCount} succeeded, ${failureCount} failed`,

--- a/dashboard/src/hooks/useRunSync.ts
+++ b/dashboard/src/hooks/useRunSync.ts
@@ -1,6 +1,6 @@
 import { useCallback } from "react";
 import { syncRun, unsyncRun } from "@/lib/api";
-import { toast } from "sonner";
+import { notifyError, notifySuccess } from "@/lib/errors";
 
 interface UseRunSyncOptions {
   onChanged?: () => void;
@@ -16,15 +16,14 @@ export function useRunSync(options: UseRunSyncOptions = {}) {
       try {
         if (isCurrentlySynced) {
           const res = await unsyncRun(runId);
-          toast.success(res.message || "Removed from Google Calendar");
+          notifySuccess(res.message || "Removed from Google Calendar");
         } else {
           const res = await syncRun(runId);
-          toast.success(res.message || "Synced to Google Calendar");
+          notifySuccess(res.message || "Synced to Google Calendar");
         }
         onChanged?.();
       } catch (err) {
-        const message = err instanceof Error ? err.message : "Operation failed";
-        toast.error(message);
+        notifyError(err, "Operation failed");
         throw err;
       } finally {
         onLoadingChange?.(runId, false);

--- a/dashboard/src/lib/errors.ts
+++ b/dashboard/src/lib/errors.ts
@@ -4,6 +4,10 @@ export function notifySuccess(message: string) {
   toast.success(message);
 }
 
+export function notifyInfo(message: string) {
+  toast.info(message);
+}
+
 export function notifyError(error: unknown, fallback: string = "Operation failed") {
   const message = error instanceof Error ? error.message : fallback;
   toast.error(message);


### PR DESCRIPTION
## Summary
- Standardize toast calls via `lib/errors` helpers
  - `useRunSync`: success/error toasts
  - `BulkSyncDialog`: success/error toasts, keep neutral `toast.message` for summary
  - `App`: refresh completion uses success/info helpers

## Rationale
- Consistent user messaging; easier to adjust globally

## Touch points
- `src/hooks/useRunSync.ts`
- `src/components/BulkSyncDialog.tsx`
- `src/App.tsx`
- `src/lib/errors.ts`

## Testing
- `npm run build` succeeds
- No behavioral changes intended beyond consistent toasts