### PR TITLE
Tests: add coverage for date util and invalidate helpers

### DIFF
--- a/dashboard/src/lib/__tests__/date.test.ts
+++ b/dashboard/src/lib/__tests__/date.test.ts
@@ -1,0 +1,20 @@
+import { describe, it, expect } from "vitest";
+import { toLocalDateTimeInputValue } from "@/lib/date";
+
+describe("toLocalDateTimeInputValue", () => {
+  it("formats a valid date to yyyy-MM-dd'T'HH:mm", () => {
+    const d = new Date(2025, 0, 2, 3, 4); // Jan 2, 2025 03:04 local time
+    const s = toLocalDateTimeInputValue(d);
+    expect(s).toBe("2025-01-02T03:04");
+  });
+
+  it("returns empty string for undefined", () => {
+    expect(toLocalDateTimeInputValue(undefined)).toBe("");
+  });
+
+  it("returns empty string for invalid Date", () => {
+    // @ts-expect-error intentionally pass invalid
+    const invalid = new Date("this is not a date");
+    expect(toLocalDateTimeInputValue(invalid)).toBe("");
+  });
+});

--- a/dashboard/src/lib/__tests__/invalidate.test.ts
+++ b/dashboard/src/lib/__tests__/invalidate.test.ts
@@ -1,0 +1,58 @@
+import { describe, it, expect, vi, beforeEach } from "vitest";
+import type { QueryClient } from "@tanstack/react-query";
+import {
+  invalidateRuns,
+  invalidateMetrics,
+  invalidateShoes,
+  invalidateEnvironment,
+  invalidateAllDash,
+} from "@/lib/invalidate";
+import { queryKeys } from "@/lib/queryKeys";
+
+describe("invalidate helpers", () => {
+  let qc: QueryClient;
+  let calls: Array<unknown>;
+
+  beforeEach(() => {
+    calls = [];
+    // minimal mock for QueryClient
+    qc = {
+      invalidateQueries: vi.fn((args: unknown) => {
+        calls.push(args);
+        return Promise.resolve();
+      }),
+    } as unknown as QueryClient;
+  });
+
+  it("invalidates runs", async () => {
+    await invalidateRuns(qc);
+    expect(calls).toEqual([{ queryKey: queryKeys.group.runs() }]);
+  });
+
+  it("invalidates metrics bundle", async () => {
+    await invalidateMetrics(qc);
+    // Expect at least these calls; order matters as implemented
+    expect(calls[0]).toEqual({ queryKey: queryKeys.totalMiles() });
+    expect(calls[1]).toEqual({ queryKey: queryKeys.milesByDay() });
+    expect(calls[2]).toEqual({ queryKey: queryKeys.rollingMiles({}) });
+    expect(calls[3]).toEqual({ queryKey: queryKeys.dayTrimp({}) });
+  });
+
+  it("invalidates shoes", async () => {
+    await invalidateShoes(qc);
+    expect(calls).toEqual([
+      { queryKey: queryKeys.shoesMileage(true) },
+      { queryKey: queryKeys.shoesMileage(false) },
+    ]);
+  });
+
+  it("invalidates environment", async () => {
+    await invalidateEnvironment(qc);
+    expect(calls).toEqual([{ queryKey: queryKeys.environment() }]);
+  });
+
+  it("invalidates all dashboard groups", async () => {
+    await invalidateAllDash(qc);
+    expect(calls.length).toBeGreaterThan(0);
+  });
+});


### PR DESCRIPTION
## Summary
- Add unit tests for:
  - `toLocalDateTimeInputValue`
  - Invalidate helpers (runs, metrics, shoes, environment, all)

## Rationale
- Locks in behavior for common utilities that other code depends on

## Testing
- `npm run test` passes locally