### PR TITLE
Fix: pace and duration rounding edge cases (7:60 → 8:00)

### DIFF
--- a/dashboard/src/lib/__tests__/runUtils.pace-duration.test.ts
+++ b/dashboard/src/lib/__tests__/runUtils.pace-duration.test.ts
@@ -1,0 +1,25 @@
+import { describe, it, expect } from "vitest";
+import { calculatePace, formatDuration } from "@/lib/runUtils";
+
+describe("calculatePace", () => {
+  it("rounds seconds and rolls over 60 to minutes", () => {
+    // duration 480s over 1 mile => 8:00
+    expect(calculatePace(1, 480)).toBe("8:00");
+    // 7:59.6 should round to 8:00 (not 7:60)
+    const duration = 7 * 60 + 59.6; // 479.6s
+    expect(calculatePace(1, duration)).toBe("8:00");
+  });
+});
+
+describe("formatDuration", () => {
+  it("formats under an hour mm:ss with correct rounding", () => {
+    expect(formatDuration(59 * 60 + 59)).toBe("59:59");
+    // 59.6 seconds rounds to 1:00
+    expect(formatDuration(60 - 0.4)).toBe("1:00");
+  });
+
+  it("formats hours as Xh Ym without rounding to invalid minutes", () => {
+    // 3599.6 seconds ~ 59:59.6 should round to 1:00:00 -> shown as 1h 0m
+    expect(formatDuration(3599.6)).toBe("1h 0m");
+  });
+});

--- a/dashboard/src/lib/runUtils.ts
+++ b/dashboard/src/lib/runUtils.ts
@@ -37,15 +37,23 @@ export function formatRunDistance(distance: number): string {
 export function calculatePace(distance: number, duration: number): string {
   if (distance === 0) return "--:--";
   const secondsPerMile = duration / distance;
-  const minutes = Math.floor(secondsPerMile / 60);
-  const seconds = Math.round(secondsPerMile % 60);
+  let minutes = Math.floor(secondsPerMile / 60);
+  const remainingSeconds = secondsPerMile - minutes * 60;
+  let seconds = Math.round(remainingSeconds);
+  if (seconds === 60) {
+    minutes += 1;
+    seconds = 0;
+  }
   return `${minutes}:${seconds.toString().padStart(2, "0")}`;
 }
 
 export function formatDuration(duration: number): string {
-  const hours = Math.floor(duration / 3600);
-  const minutes = Math.floor((duration % 3600) / 60);
-  const seconds = duration % 60;
+  // Normalize to whole seconds in case a float sneaks in
+  const totalSeconds = Math.round(duration);
+  const hours = Math.floor(totalSeconds / 3600);
+  const rem = totalSeconds % 3600;
+  const minutes = Math.floor(rem / 60);
+  const seconds = rem % 60;
 
   if (hours > 0) {
     return `${hours}h ${minutes}m`;


### PR DESCRIPTION
## Summary
- Fix frontend rounding in pacing and duration display
  - `calculatePace`: rounds seconds and rolls 60s up to next minute to avoid `7:60`
  - `formatDuration`: rounds total seconds and formats `1h 0m` instead of invalid values
- Add tests covering rollover and rounding edge cases

## Why
- Users observed `7:60` paces due to rounding; needs correct carry to minutes

## Files
- `src/lib/runUtils.ts`
- `src/lib/__tests__/runUtils.pace-duration.test.ts`

## Testing
- `npm run test` passes
- Visual check: paces like 7:59.6 now display 8:00