### PR TITLE
Feature: add TRIMP column and configurable HR settings

### DIFF
--- a/dashboard/src/App.tsx
+++ b/dashboard/src/App.tsx
@@ -34,7 +34,7 @@ function App() {
         </div>
       </div>
       <div className="flex flex-row justify-between gap-x-6 mb-8 flex-shrink-0">
-        <div className="flex flex-col gap-y-6 w-64 flex-grow-0">
+        <div className="flex flex-col gap-y-6 w-52 flex-grow-0">
           <AllTimeStatsPanel />
           <HRSettingsPanel />
         </div>

--- a/dashboard/src/App.tsx
+++ b/dashboard/src/App.tsx
@@ -34,7 +34,7 @@ function App() {
         </div>
       </div>
       <div className="flex flex-row justify-between gap-x-6 mb-8 flex-shrink-0">
-        <div className="flex flex-col gap-y-6 w-48 flex-grow-0">
+        <div className="flex flex-col gap-y-6 w-64 flex-grow-0">
           <AllTimeStatsPanel />
           <HRSettingsPanel />
         </div>

--- a/dashboard/src/App.tsx
+++ b/dashboard/src/App.tsx
@@ -7,6 +7,7 @@ import {
 import { RefreshButton } from "./components/RefreshButton";
 import { EnvironmentIndicator } from "./components/EnvironmentIndicator";
 import { ThemeToggle } from "./components/ThemeToggle";
+import { HRSettingsPanel } from "./components/HRSettingsPanel";
 import { Toaster } from "./components/ui/sonner";
 import { notifySuccess, notifyInfo } from "@/lib/errors";
 import type { RefreshDataResponse } from "./lib/api/fetch";
@@ -33,7 +34,10 @@ function App() {
         </div>
       </div>
       <div className="flex flex-row justify-between gap-x-6 mb-8 flex-shrink-0">
-        <AllTimeStatsPanel className="w-48 flex-grow-0" />
+        <div className="flex flex-col gap-y-6 w-48 flex-grow-0">
+          <AllTimeStatsPanel />
+          <HRSettingsPanel />
+        </div>
         <div className="flex-1 min-w-[480px]">
           <TimePeriodStatsPanel />
         </div>

--- a/dashboard/src/components/HRSettingsPanel.tsx
+++ b/dashboard/src/components/HRSettingsPanel.tsx
@@ -88,7 +88,7 @@ export function HRSettingsPanel({ className }: HRSettingsPanelProps) {
             onChange={(e) => handleMaxHrChange(e.target.value)}
             min="100"
             max="250"
-            className="w-full"
+            className="w-20"
           />
         </div>
         
@@ -101,14 +101,14 @@ export function HRSettingsPanel({ className }: HRSettingsPanelProps) {
             onChange={(e) => handleRestingHrChange(e.target.value)}
             min="30"
             max="100"
-            className="w-full"
+            className="w-20"
           />
         </div>
 
         <div className="space-y-2">
           <Label htmlFor="sex">Sex</Label>
           <Select value={sex} onValueChange={handleSexChange}>
-            <SelectTrigger>
+            <SelectTrigger className="w-24">
               <SelectValue />
             </SelectTrigger>
             <SelectContent>

--- a/dashboard/src/components/HRSettingsPanel.tsx
+++ b/dashboard/src/components/HRSettingsPanel.tsx
@@ -18,8 +18,9 @@ interface HRSettingsPanelProps {
 }
 
 export function HRSettingsPanel({ className }: HRSettingsPanelProps) {
-  const { maxHr, setMaxHr, restingHr, setRestingHr, sex, setSex } = useDashboardStore();
-  
+  const { maxHr, setMaxHr, restingHr, setRestingHr, sex, setSex } =
+    useDashboardStore();
+
   // Local state for input values to handle validation
   const [localMaxHr, setLocalMaxHr] = useState(maxHr.toString());
   const [localRestingHr, setLocalRestingHr] = useState(restingHr.toString());
@@ -77,7 +78,7 @@ export function HRSettingsPanel({ className }: HRSettingsPanelProps) {
         <Settings className="h-4 w-4" />
         <h3 className="font-medium">Heart Rate Settings</h3>
       </div>
-      
+
       <div className="space-y-4">
         <div className="space-y-2">
           <Label htmlFor="maxHr">Max HR (bpm)</Label>
@@ -91,7 +92,7 @@ export function HRSettingsPanel({ className }: HRSettingsPanelProps) {
             className="w-20"
           />
         </div>
-        
+
         <div className="space-y-2">
           <Label htmlFor="restingHr">Resting HR (bpm)</Label>
           <Input
@@ -129,7 +130,7 @@ export function HRSettingsPanel({ className }: HRSettingsPanelProps) {
           </div>
         )}
       </div>
-      
+
       <p className="text-xs text-muted-foreground mt-3">
         These settings affect TRIMP calculations and training load analysis.
       </p>

--- a/dashboard/src/components/HRSettingsPanel.tsx
+++ b/dashboard/src/components/HRSettingsPanel.tsx
@@ -79,32 +79,30 @@ export function HRSettingsPanel({ className }: HRSettingsPanelProps) {
       </div>
       
       <div className="space-y-4">
-        <div className="grid grid-cols-2 gap-4">
-          <div className="space-y-2">
-            <Label htmlFor="maxHr">Max HR (bpm)</Label>
-            <Input
-              id="maxHr"
-              type="number"
-              value={localMaxHr}
-              onChange={(e) => handleMaxHrChange(e.target.value)}
-              min="100"
-              max="250"
-              className="w-full"
-            />
-          </div>
-          
-          <div className="space-y-2">
-            <Label htmlFor="restingHr">Resting HR (bpm)</Label>
-            <Input
-              id="restingHr"
-              type="number"
-              value={localRestingHr}
-              onChange={(e) => handleRestingHrChange(e.target.value)}
-              min="30"
-              max="100"
-              className="w-full"
-            />
-          </div>
+        <div className="space-y-2">
+          <Label htmlFor="maxHr">Max HR (bpm)</Label>
+          <Input
+            id="maxHr"
+            type="number"
+            value={localMaxHr}
+            onChange={(e) => handleMaxHrChange(e.target.value)}
+            min="100"
+            max="250"
+            className="w-full"
+          />
+        </div>
+        
+        <div className="space-y-2">
+          <Label htmlFor="restingHr">Resting HR (bpm)</Label>
+          <Input
+            id="restingHr"
+            type="number"
+            value={localRestingHr}
+            onChange={(e) => handleRestingHrChange(e.target.value)}
+            min="30"
+            max="100"
+            className="w-full"
+          />
         </div>
 
         <div className="space-y-2">

--- a/dashboard/src/components/HRSettingsPanel.tsx
+++ b/dashboard/src/components/HRSettingsPanel.tsx
@@ -1,0 +1,140 @@
+import { useState } from "react";
+import { Card } from "@/components/ui/card";
+import { Button } from "@/components/ui/button";
+import { Input } from "@/components/ui/input";
+import { Label } from "@/components/ui/label";
+import {
+  Select,
+  SelectContent,
+  SelectItem,
+  SelectTrigger,
+  SelectValue,
+} from "@/components/ui/select";
+import { useDashboardStore } from "@/store";
+import { Settings } from "lucide-react";
+
+interface HRSettingsPanelProps {
+  className?: string;
+}
+
+export function HRSettingsPanel({ className }: HRSettingsPanelProps) {
+  const { maxHr, setMaxHr, restingHr, setRestingHr, sex, setSex } = useDashboardStore();
+  
+  // Local state for input values to handle validation
+  const [localMaxHr, setLocalMaxHr] = useState(maxHr.toString());
+  const [localRestingHr, setLocalRestingHr] = useState(restingHr.toString());
+  const [hasUnsavedChanges, setHasUnsavedChanges] = useState(false);
+
+  const handleMaxHrChange = (value: string) => {
+    setLocalMaxHr(value);
+    setHasUnsavedChanges(true);
+  };
+
+  const handleRestingHrChange = (value: string) => {
+    setLocalRestingHr(value);
+    setHasUnsavedChanges(true);
+  };
+
+  const handleSexChange = (value: "M" | "F") => {
+    setSex(value);
+    // Sex changes are applied immediately
+  };
+
+  const handleSave = () => {
+    const maxHrNum = parseInt(localMaxHr);
+    const restingHrNum = parseInt(localRestingHr);
+
+    // Validation
+    if (isNaN(maxHrNum) || maxHrNum < 100 || maxHrNum > 250) {
+      alert("Max HR must be between 100 and 250 bpm");
+      return;
+    }
+
+    if (isNaN(restingHrNum) || restingHrNum < 30 || restingHrNum > 100) {
+      alert("Resting HR must be between 30 and 100 bpm");
+      return;
+    }
+
+    if (restingHrNum >= maxHrNum) {
+      alert("Resting HR must be less than Max HR");
+      return;
+    }
+
+    setMaxHr(maxHrNum);
+    setRestingHr(restingHrNum);
+    setHasUnsavedChanges(false);
+  };
+
+  const handleReset = () => {
+    setLocalMaxHr(maxHr.toString());
+    setLocalRestingHr(restingHr.toString());
+    setHasUnsavedChanges(false);
+  };
+
+  return (
+    <Card className={`p-4 ${className}`}>
+      <div className="flex items-center gap-2 mb-4">
+        <Settings className="h-4 w-4" />
+        <h3 className="font-medium">Heart Rate Settings</h3>
+      </div>
+      
+      <div className="space-y-4">
+        <div className="grid grid-cols-2 gap-4">
+          <div className="space-y-2">
+            <Label htmlFor="maxHr">Max HR (bpm)</Label>
+            <Input
+              id="maxHr"
+              type="number"
+              value={localMaxHr}
+              onChange={(e) => handleMaxHrChange(e.target.value)}
+              min="100"
+              max="250"
+              className="w-full"
+            />
+          </div>
+          
+          <div className="space-y-2">
+            <Label htmlFor="restingHr">Resting HR (bpm)</Label>
+            <Input
+              id="restingHr"
+              type="number"
+              value={localRestingHr}
+              onChange={(e) => handleRestingHrChange(e.target.value)}
+              min="30"
+              max="100"
+              className="w-full"
+            />
+          </div>
+        </div>
+
+        <div className="space-y-2">
+          <Label htmlFor="sex">Sex</Label>
+          <Select value={sex} onValueChange={handleSexChange}>
+            <SelectTrigger>
+              <SelectValue />
+            </SelectTrigger>
+            <SelectContent>
+              <SelectItem value="M">Male</SelectItem>
+              <SelectItem value="F">Female</SelectItem>
+            </SelectContent>
+          </Select>
+        </div>
+
+        {hasUnsavedChanges && (
+          <div className="flex gap-2 pt-2">
+            <Button onClick={handleSave} size="sm">
+              Save Changes
+            </Button>
+            <Button onClick={handleReset} variant="outline" size="sm">
+              Reset
+            </Button>
+          </div>
+        )}
+      </div>
+      
+      <p className="text-xs text-muted-foreground mt-3">
+        These settings affect TRIMP calculations and training load analysis.
+      </p>
+    </Card>
+  );
+}

--- a/dashboard/src/components/RunsTable.tsx
+++ b/dashboard/src/components/RunsTable.tsx
@@ -393,7 +393,12 @@ function RunTableRow({
           <tr className="border-b bg-muted/20">
             <td></td>
             <td colSpan={7} className="p-3">
-              <RunExpandedDetails run={run} maxHr={maxHr} restingHr={restingHr} sex={sex} />
+              <RunExpandedDetails
+                run={run}
+                maxHr={maxHr}
+                restingHr={restingHr}
+                sex={sex}
+              />
               {
                 <div className="mt-3 flex items-center gap-2">
                   <SyncStatusBadge
@@ -428,12 +433,12 @@ function RunTableRow({
   }
 }
 
-function RunExpandedDetails({ 
-  run, 
-  maxHr, 
-  restingHr, 
-  sex 
-}: { 
+function RunExpandedDetails({
+  run,
+  maxHr,
+  restingHr,
+  sex,
+}: {
   run: RunDetail;
   maxHr: number;
   restingHr: number;

--- a/dashboard/src/components/RunsTable.tsx
+++ b/dashboard/src/components/RunsTable.tsx
@@ -22,6 +22,7 @@ import {
   formatHeartRate,
   truncateText,
 } from "@/lib/runUtils";
+import { calculateTrimp, formatTrimp } from "@/lib/trimpUtils";
 import { cn } from "@/lib/utils";
 import { Button } from "@/components/ui/button";
 import {
@@ -174,6 +175,9 @@ export function RunsTable({
               >
                 HR
               </SortableHeader>
+              <th className="p-3 font-medium bg-muted/50 text-center hidden md:table-cell">
+                TRIMP
+              </th>
               <SortableHeader sortKey="shoes" className="hidden lg:table-cell">
                 Shoes
               </SortableHeader>
@@ -367,6 +371,9 @@ function RunTableRow({
           <td className="p-3 hidden md:table-cell">
             {formatHeartRate(run.avg_heart_rate)}
           </td>
+          <td className="p-3 text-center hidden md:table-cell">
+            {formatTrimp(calculateTrimp(run))}
+          </td>
           <td className="p-3 text-sm text-muted-foreground hidden lg:table-cell">
             {truncateText(run.shoes, 20)}
           </td>
@@ -374,7 +381,7 @@ function RunTableRow({
         {isExpanded && (
           <tr className="border-b bg-muted/20">
             <td></td>
-            <td colSpan={6} className="p-3">
+            <td colSpan={7} className="p-3">
               <RunExpandedDetails run={run} />
               {
                 <div className="mt-3 flex items-center gap-2">
@@ -402,7 +409,7 @@ function RunTableRow({
     console.error("Error rendering run row:", error, run);
     return (
       <tr className="border-b">
-        <td colSpan={6} className="p-3 text-destructive">
+        <td colSpan={7} className="p-3 text-destructive">
           Error displaying run data
         </td>
       </tr>
@@ -427,6 +434,14 @@ function RunExpandedDetails({ run }: { run: RunDetail }) {
           <span className="font-medium">HR:</span>{" "}
           {formatHeartRate(run.avg_heart_rate)}{" "}
           {run.avg_heart_rate ? "bpm" : ""}
+        </span>
+      </div>
+
+      {/* Show TRIMP on mobile and small screens (hidden in main row) */}
+      <div className="flex items-center gap-2 md:hidden">
+        <span className="text-sm">
+          <span className="font-medium">TRIMP:</span>{" "}
+          {formatTrimp(calculateTrimp(run))}
         </span>
       </div>
 

--- a/dashboard/src/components/RunsTable.tsx
+++ b/dashboard/src/components/RunsTable.tsx
@@ -23,6 +23,7 @@ import {
   truncateText,
 } from "@/lib/runUtils";
 import { calculateTrimp, formatTrimp } from "@/lib/trimpUtils";
+import { useDashboardStore } from "@/store";
 import { cn } from "@/lib/utils";
 import { Button } from "@/components/ui/button";
 import {
@@ -57,6 +58,7 @@ export function RunsTable({
   onRunUpdated,
   onSyncChanged,
 }: RunsTableProps) {
+  const { maxHr, restingHr, sex } = useDashboardStore();
   const [expandedRows, setExpandedRows] = useState<Set<number>>(new Set());
   const [editRun, setEditRun] = useState<RunDetail | null>(null);
   const [isEditDialogOpen, setIsEditDialogOpen] = useState(false);
@@ -197,6 +199,9 @@ export function RunsTable({
                 onToggleSync={handleToggleSync}
                 syncingRunIds={syncingRunIds}
                 setSyncingRunIds={setSyncingRunIds}
+                maxHr={maxHr}
+                restingHr={restingHr}
+                sex={sex}
               />
             ))}
           </tbody>
@@ -230,6 +235,9 @@ interface RunTableRowProps {
   onToggleSync: (runId: string, isSynced: boolean) => Promise<void> | void;
   syncingRunIds: Set<string>;
   setSyncingRunIds: React.Dispatch<React.SetStateAction<Set<string>>>;
+  maxHr: number;
+  restingHr: number;
+  sex: "M" | "F";
 }
 
 function RunTableRow({
@@ -242,6 +250,9 @@ function RunTableRow({
   onToggleSync,
   syncingRunIds,
   setSyncingRunIds,
+  maxHr,
+  restingHr,
+  sex,
 }: RunTableRowProps) {
   try {
     const runId = run.id;
@@ -372,7 +383,7 @@ function RunTableRow({
             {formatHeartRate(run.avg_heart_rate)}
           </td>
           <td className="p-3 text-center hidden md:table-cell">
-            {formatTrimp(calculateTrimp(run))}
+            {formatTrimp(calculateTrimp(run, maxHr, restingHr, sex))}
           </td>
           <td className="p-3 text-sm text-muted-foreground hidden lg:table-cell">
             {truncateText(run.shoes, 20)}
@@ -382,7 +393,7 @@ function RunTableRow({
           <tr className="border-b bg-muted/20">
             <td></td>
             <td colSpan={7} className="p-3">
-              <RunExpandedDetails run={run} />
+              <RunExpandedDetails run={run} maxHr={maxHr} restingHr={restingHr} sex={sex} />
               {
                 <div className="mt-3 flex items-center gap-2">
                   <SyncStatusBadge
@@ -417,7 +428,17 @@ function RunTableRow({
   }
 }
 
-function RunExpandedDetails({ run }: { run: RunDetail }) {
+function RunExpandedDetails({ 
+  run, 
+  maxHr, 
+  restingHr, 
+  sex 
+}: { 
+  run: RunDetail;
+  maxHr: number;
+  restingHr: number;
+  sex: "M" | "F";
+}) {
   return (
     <div className="grid grid-cols-1 sm:grid-cols-2 gap-4 py-2">
       {/* Show pace on mobile (hidden in main row) */}
@@ -441,7 +462,7 @@ function RunExpandedDetails({ run }: { run: RunDetail }) {
       <div className="flex items-center gap-2 md:hidden">
         <span className="text-sm">
           <span className="font-medium">TRIMP:</span>{" "}
-          {formatTrimp(calculateTrimp(run))}
+          {formatTrimp(calculateTrimp(run, maxHr, restingHr, sex))}
         </span>
       </div>
 

--- a/dashboard/src/lib/trimpUtils.ts
+++ b/dashboard/src/lib/trimpUtils.ts
@@ -1,0 +1,54 @@
+import type { RunDetail } from "@/lib/api";
+
+// Constants matching the API implementation
+const DEFAULT_MAX_HR = 192;
+const DEFAULT_RESTING_HR = 42;
+const DEFAULT_SEX = "M" as const;
+
+/**
+ * Calculate the Banister TRaining IMPulse score for a run.
+ * 
+ * TRIMP = Duration (minutes) x HR_Relative x Y
+ * where HR_Relative is the relative heart rate:
+ *   - HR_Relative = (avg_hr_during_for_activity - resting_hr) / (max_hr - resting_hr)
+ * where Y is a sex-based weighting factor:
+ *   - For men: Y = 0.64 * e^(1.92 x HR_Relative)
+ *   - For women: Y = 0.86 * e^(1.67 x HR_Relative)
+ */
+export function calculateTrimp(
+  run: RunDetail,
+  maxHr: number = DEFAULT_MAX_HR,
+  restingHr: number = DEFAULT_RESTING_HR,
+  sex: "M" | "F" = DEFAULT_SEX
+): number | null {
+  if (!run.avg_heart_rate || run.avg_heart_rate <= 0) {
+    return null;
+  }
+
+  const hrRelative = (run.avg_heart_rate - restingHr) / (maxHr - restingHr);
+  // Clamp hr_relative to the range [0, 1]
+  const clampedHrRelative = Math.max(0.0, Math.min(1.0, hrRelative));
+  
+  let y: number;
+  switch (sex) {
+    case "M":
+      y = 0.64 * Math.exp(1.92 * clampedHrRelative);
+      break;
+    case "F":
+      y = 0.86 * Math.exp(1.67 * clampedHrRelative);
+      break;
+  }
+
+  const durationMinutes = run.duration / 60;
+  return durationMinutes * clampedHrRelative * y;
+}
+
+/**
+ * Format TRIMP value for display
+ */
+export function formatTrimp(trimp: number | null): string {
+  if (trimp === null || trimp === undefined) {
+    return "--";
+  }
+  return trimp.toFixed(1);
+}

--- a/dashboard/src/lib/trimpUtils.ts
+++ b/dashboard/src/lib/trimpUtils.ts
@@ -7,7 +7,7 @@ const DEFAULT_SEX = "M" as const;
 
 /**
  * Calculate the Banister TRaining IMPulse score for a run.
- * 
+ *
  * TRIMP = Duration (minutes) x HR_Relative x Y
  * where HR_Relative is the relative heart rate:
  *   - HR_Relative = (avg_hr_during_for_activity - resting_hr) / (max_hr - resting_hr)
@@ -19,7 +19,7 @@ export function calculateTrimp(
   run: RunDetail,
   maxHr: number = DEFAULT_MAX_HR,
   restingHr: number = DEFAULT_RESTING_HR,
-  sex: "M" | "F" = DEFAULT_SEX
+  sex: "M" | "F" = DEFAULT_SEX,
 ): number | null {
   if (!run.avg_heart_rate || run.avg_heart_rate <= 0) {
     return null;
@@ -28,7 +28,7 @@ export function calculateTrimp(
   const hrRelative = (run.avg_heart_rate - restingHr) / (maxHr - restingHr);
   // Clamp hr_relative to the range [0, 1]
   const clampedHrRelative = Math.max(0.0, Math.min(1.0, hrRelative));
-  
+
   let y: number;
   switch (sex) {
     case "M":

--- a/dashboard/src/panels/TimePeriodStatsPanel/TimePeriodStatsPanel.tsx
+++ b/dashboard/src/panels/TimePeriodStatsPanel/TimePeriodStatsPanel.tsx
@@ -127,7 +127,7 @@ type TimePeriodStatsResult =
 
 function useTimePeriodStats(): TimePeriodStatsResult {
   const store = useDashboardStore();
-  const { timeRangeStart, timeRangeEnd } = store;
+  const { timeRangeStart, timeRangeEnd, maxHr, restingHr, sex } = store;
   const userTimezone = getUserTimezone();
 
   const milesQueryResult = useQuery({
@@ -175,18 +175,18 @@ function useTimePeriodStats(): TimePeriodStatsResult {
     queryKey: queryKeys.trainingLoadByDay({
       startDate: timeRangeStart,
       endDate: timeRangeEnd,
-      maxHr: 192,
-      restingHr: 42,
-      sex: "M",
+      maxHr,
+      restingHr,
+      sex,
       userTimezone,
     }),
     queryFn: () =>
       fetchDayTrainingLoad({
         startDate: timeRangeStart,
         endDate: timeRangeEnd,
-        maxHr: 192,
-        restingHr: 42,
-        sex: "M",
+        maxHr,
+        restingHr,
+        sex,
         userTimezone,
       }),
   });

--- a/dashboard/src/store.ts
+++ b/dashboard/src/store.ts
@@ -124,8 +124,14 @@ export const useDashboardStore = create<DashboardState>()(
       storage: createJSONStorage(() => localStorage),
       partialize: (state) => ({
         selectedTimePeriod: state.selectedTimePeriod,
-        timeRangeStart: state.timeRangeStart instanceof Date ? state.timeRangeStart.toISOString() : state.timeRangeStart,
-        timeRangeEnd: state.timeRangeEnd instanceof Date ? state.timeRangeEnd.toISOString() : state.timeRangeEnd,
+        timeRangeStart:
+          state.timeRangeStart instanceof Date
+            ? state.timeRangeStart.toISOString()
+            : state.timeRangeStart,
+        timeRangeEnd:
+          state.timeRangeEnd instanceof Date
+            ? state.timeRangeEnd.toISOString()
+            : state.timeRangeEnd,
         theme: state.theme,
         maxHr: state.maxHr,
         restingHr: state.restingHr,

--- a/dashboard/src/store.ts
+++ b/dashboard/src/store.ts
@@ -16,11 +16,22 @@ type DashboardState = {
   selectTimePeriod: (period: TimePeriodType) => void;
   theme: Theme;
   setTheme: (theme: Theme) => void;
+  maxHr: number;
+  setMaxHr: (maxHr: number) => void;
+  restingHr: number;
+  setRestingHr: (restingHr: number) => void;
+  sex: "M" | "F";
+  setSex: (sex: "M" | "F") => void;
 };
 
 // Defaults if nothing persisted
 const defaultPeriod: TimePeriodType = "30_days";
 const defaultOption = getTimePeriodById(defaultPeriod)!;
+
+// Default HR settings matching existing hardcoded values
+const DEFAULT_MAX_HR = 192;
+const DEFAULT_RESTING_HR = 42;
+const DEFAULT_SEX = "M" as const;
 
 // Theme utilities
 const getSystemTheme = (): "light" | "dark" => {
@@ -97,16 +108,28 @@ export const useDashboardStore = create<DashboardState>()(
 
         set({ theme });
       },
+
+      maxHr: DEFAULT_MAX_HR,
+      setMaxHr: (maxHr) => set({ maxHr }),
+
+      restingHr: DEFAULT_RESTING_HR,
+      setRestingHr: (restingHr) => set({ restingHr }),
+
+      sex: DEFAULT_SEX,
+      setSex: (sex) => set({ sex }),
     }),
     {
       name: "dashboard-store",
-      version: 3,
+      version: 4,
       storage: createJSONStorage(() => localStorage),
       partialize: (state) => ({
         selectedTimePeriod: state.selectedTimePeriod,
-        timeRangeStart: state.timeRangeStart.toISOString(),
-        timeRangeEnd: state.timeRangeEnd.toISOString(),
+        timeRangeStart: state.timeRangeStart instanceof Date ? state.timeRangeStart.toISOString() : state.timeRangeStart,
+        timeRangeEnd: state.timeRangeEnd instanceof Date ? state.timeRangeEnd.toISOString() : state.timeRangeEnd,
         theme: state.theme,
+        maxHr: state.maxHr,
+        restingHr: state.restingHr,
+        sex: state.sex,
       }),
       migrate: (persisted) => {
         const ps = persisted as unknown as {


### PR DESCRIPTION
## Summary
- Adds a new TRIMP (Training Impulse) column to the Recent Runs table
- Adds configurable HR settings panel for personalized calculations
- Updates training load charts to use user-configured HR parameters
- Fixes Safari date serialization error

## New Features
### TRIMP Column
- Shows calculated TRIMP values for runs with heart rate data using the Banister formula
- Responsive design with mobile support
- Displays "--" for runs without heart rate data

### HR Settings Panel
- Compact settings panel with Max HR, Resting HR, and Sex inputs
- Input validation with helpful error messages
- Real-time updates affecting both TRIMP calculations and training load analysis
- Persisted to localStorage with unsaved changes detection

### Cross-Platform Compatibility
- Fixed Safari date serialization error with type guards
- Maintains backward compatibility

## Changes
- **New utility**: `trimpUtils.ts` with TRIMP calculation and formatting functions
- **Enhanced table**: Added TRIMP column between HR and Shoes in RunsTable
- **New component**: `HRSettingsPanel` with validation and persistence
- **Updated store**: Added HR settings state management with localStorage
- **Enhanced charts**: Training load analysis now uses configurable HR parameters
- **Layout optimization**: Compact, space-efficient design

## Technical Details
- Frontend TRIMP calculation for optimal performance
- TRIMP = Duration × HR_Relative × Y (Banister formula)
- Default values: max_hr=192, resting_hr=42, sex="M" (matching existing constants)
- Real-time recalculation when HR settings change
- Store version bump with migration support

## Test Plan
- [x] Lint and build checks pass
- [x] TRIMP values display correctly for runs with heart rate data
- [x] HR settings panel validation works properly
- [x] Training load charts update when HR settings change
- [x] Safari compatibility verified
- [x] Responsive design works on mobile devices
- [x] LocalStorage persistence functions correctly

🤖 Generated with [Claude Code](https://claude.ai/code)